### PR TITLE
Repair broken link

### DIFF
--- a/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -72,7 +72,7 @@ the X-delta between points `bottom` and `right`.
 <Tip>
 
 Points come with a bunch of these methods. 
-You can find them all in [the Point API docs](/referene/api/point/).
+You can find them all in [the Point API docs](/reference/api/point/).
 
 </Tip>
 


### PR DESCRIPTION
Added one letter ("c") to fix broken link to API docs.