### PR TITLE
Minor typos in tutorial text in "drawing the bib outline

### DIFF
--- a/dev/tutorials/pattern-design/drawing-the-bib-outline/en.md
+++ b/dev/tutorials/pattern-design/drawing-the-bib-outline/en.md
@@ -2,7 +2,7 @@
 title: 190|Drawing the bib outline
 ---
 
-With our neck opening in place, let's draw basic outline of our bib:
+With our neck opening in place, let's draw the basic outline of our bib:
 
 ```js
 let width = measurements.headCircumference * options.widthRatio;
@@ -25,7 +25,7 @@ paths.rect = new Path()
   .close();
 ```
 
-Firs thing we did was create the `width` and `length` variables to
+First thing we did was create the `width` and `length` variables to
 save ourselves some typing:
 
 ```js


### PR DESCRIPTION
from "let’s draw basic outline of our bib:" to  "let’s draw the basic outline of our bib:"
and
from "Firs thing we did"  to "First thing we did"

Dunno if I'm doing something wrong, but it gave me the message:
"You're making changes in a project you don't have write access to"