### PR TITLE
Minor fixes: typos, moved images, markdown syntax errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/org/docs/patterns/florent/cutting/en.md
+++ b/org/docs/patterns/florent/cutting/en.md
@@ -5,7 +5,7 @@ title: Cutting
 Depending on how much fabric is available, you might want to cut two top and or side parts, hence the instructions on the pattern himself.
 Warning: The pattern includes the seam allowances on the top part so if you cut it on fold, don't include them!
 
-The brim bottom part is inset, while the brim top part is offset so that the seam falls "underneath the brim edge". 
+The brim bottom part is inset, while the brim top part is offset so that the seam falls "underneath the brim edge".
 Keep that in mind when cutting the parts, and mark them accordingly, so that you don't end up with the seam on top of the brim (I don't want to force you into this design choice, I simply want to point out the difference between the parts so that you are aware of it and act accordingly)
 
  - **Main fabric**
@@ -21,5 +21,4 @@ Keep that in mind when cutting the parts, and mark them accordingly, so that you
 
 A typical Florent layout looks like this:
 
-![A typical Florent layout](/img/patterns/florent/layout.svg)
-
+![A typical Florent layout](layout.svg)

--- a/org/docs/patterns/jaeger/cutting/en.md
+++ b/org/docs/patterns/jaeger/cutting/en.md
@@ -27,9 +27,9 @@
 
 <Note>
 
-####### Good sides together, or precise pattern matching?
+###### Good sides together, or precise pattern matching?
 
-When cutting out two, you can cut them [good sides together](/en/docs/sewing/good-sides-together).
+When cutting out two, you can cut them [good sides together](/docs/sewing/good-sides-together).
 However, when working with fabric with a pattern, I prefer to cut them individually to finely control the pattern matching.
 
 When you cut them individually, remember that they need to be mirror images of each other. So flip either your pattern or your fabric over when cutting the second one.
@@ -47,5 +47,3 @@ When you cut them individually, remember that they need to be mirror images of e
 ![Trace the front facing and lining from the front part](cuttingCaveat.svg)
 
 </Warning>
-
-

--- a/org/docs/patterns/jaeger/instructions/en.md
+++ b/org/docs/patterns/jaeger/instructions/en.md
@@ -1,6 +1,6 @@
 <Note>
 
-####### Jaeger documentation is under construction
+###### Jaeger documentation is under construction
 
 This documentation is not yet finished.
 
@@ -18,15 +18,15 @@ Fold the front double with the good sides together and pin it down so the fold i
 
 #### Sew darts
 
-Sew the front dart close, taking care to have the dart stop at the correct top end. 
-The bottom is not that important as it will be covered by the pockets. 
+Sew the front dart close, taking care to have the dart stop at the correct top end.
+The bottom is not that important as it will be covered by the pockets.
 But the top end of the dart will be clearly visible, so please make sure to have it end at the same height at both sides.
 
 #### Cut open and press
 
-Once the front darts are closed, cut open the dart at the back. 
+Once the front darts are closed, cut open the dart at the back.
 You won't be able to cut it open all the way to the tip, but that's fine.
-Press open the darts where they are cut open, and press the rest to the side. 
+Press open the darts where they are cut open, and press the rest to the side.
 Take care to only press from the back. Pressing from the front will likely mark your fabric.
 
 
@@ -39,9 +39,9 @@ Take care to only press from the back. Pressing from the front will likely mark 
 Apply a rectangular piece of light fusible interfacing around the chest pocket area so that it extends a few cm in all directions.
 
 > ##### We're not using fusible on the entire front
-> 
-> Sportcoats are typically made from somewhat heavier fabrics. 
-> That, and the fact that I prefer to use canvas rather than fusible interfacing, 
+>
+> Sportcoats are typically made from somewhat heavier fabrics.
+> That, and the fact that I prefer to use canvas rather than fusible interfacing,
 > means that I don't interface the front with fusible.
 {.fs-bq}
 
@@ -52,7 +52,7 @@ transfer the markings to the good side of the fabric.
 
 This pocket differs from a traditional welt pocket. The welt extends above the pocket opening. This hides the pocket bag without the need for facings. The top part of the opening is also smaller than the welt, allowing you to slip-stitch it closed.
 
-On the top line of your basted welt pocket, mark 0.5cm inwards from the corners of the top line. 
+On the top line of your basted welt pocket, mark 0.5cm inwards from the corners of the top line.
 
 > These points are notches on the front part of your pattern.
 
@@ -60,7 +60,7 @@ On the top line of your basted welt pocket, mark 0.5cm inwards from the corners 
 
 #### Fold, press and sew the side seams of the welt
 
-Fold the welt double with the good sides together, and close the sides (sew the side seams). 
+Fold the welt double with the good sides together, and close the sides (sew the side seams).
 
 #### Trim seam allowance, turn and press
 Trim the seam allowances on the sides and especially limit the seam allowance towards the corner to avoid bulk.
@@ -78,15 +78,15 @@ This will be the line to sew on later.
 
 ![Attach the chest pocket welt to the front](attachChestPocketWelt.svg)
 
-Place welt down on good side of front with the folded side downwards, and sew to bottom line. 
+Place welt down on good side of front with the folded side downwards, and sew to bottom line.
 Make sure to stop and start exactly at the edge of the line you basted.
 
 #### Sew the chest pocket bag to the front
 
 ![Attach the chest pocket bag to the front](attachChestPocketBag.svg)
 
-Place the pocket bag down on the front. 
-The front with good side up, but the pocket bag with bad side up. 
+Place the pocket bag down on the front.
+The front with good side up, but the pocket bag with bad side up.
 Make sure to have the longest side of the chest pocket bag on the highest side of the chest pocket.
 
 > Only slanted chest pockets have a higher and lower side.
@@ -99,14 +99,14 @@ to attach the welt, since you marked 0.5cm inwards from the corners.
 #### Cut open chest pocket opening, turn, and press
 
 ![Press the chest pocket](pressChestPocket.svg)
-Now cut open your welt in the middle of both seamlines. 
+Now cut open your welt in the middle of both seamlines.
 Don't cut to the edge, but create a trianngular shape there.
 
 Flip the pocket bag and welt to the backside by passing both of them through the opening you just created.
 
 Get everything to lay nice and flat, and press.
 
-Now, bring the welt only to the front and get it to lie nice and flat. 
+Now, bring the welt only to the front and get it to lie nice and flat.
 Press again from the back.
 
 > Resist the urge to press this from the front.
@@ -115,12 +115,12 @@ Press again from the back.
 
 ![Finish the chest pocket](finishChestPocket.svg)
 
-On the backside, fold the pocket bag double and sew it to the pocket 
+On the backside, fold the pocket bag double and sew it to the pocket
 welt below the existing seamline of the welt.
 
-Thread a needle and hand-finish the chest pocket by sewing down the sides of the welt to the front panel (don't let your stitches show on the front). 
+Thread a needle and hand-finish the chest pocket by sewing down the sides of the welt to the front panel (don't let your stitches show on the front).
 
-Finally, close the pocket bag by sewing the sides. 
+Finally, close the pocket bag by sewing the sides.
 Do this by placing the front down with the good side up. Then fold over each side and sew the pocket bag. While sewing these sides, make sure to catch those triangular little pieces of the opening. This will reinforce the pocket opening.
 
 Baste the chest pocket closed while we contruct the jacket.
@@ -130,11 +130,11 @@ Baste the chest pocket closed while we contruct the jacket.
 
 ![Prepare the canvas for the fronts](prepareCanvas.svg)
 
-Cut out the front canvas piece in a light and supple canvas placed on the bias. Cut out the entire front. 
+Cut out the front canvas piece in a light and supple canvas placed on the bias. Cut out the entire front.
 
 Cut out the front dart and close it with a zig-zag stitch, making sure not to let the canvas overlap.
 
-Cut out the chest canvas piece. Align it along the roll line, and baste it in place on front canvas piece. 
+Cut out the chest canvas piece. Align it along the roll line, and baste it in place on front canvas piece.
 
 > The chest piece is marked on the front part of your pattern.
 
@@ -144,17 +144,17 @@ Cut out the chest canvas piece. Align it along the roll line, and baste it in pl
 
 Now baste the front canvas and chest piece to your front. Keep in mind that the canvas has no seam allowance.
 
-> Base it a bit inwards from the seam line so you can fold it away when sewing these seams later.  
+> Base it a bit inwards from the seam line so you can fold it away when sewing these seams later.
 > You don't want your canvas to get caught in the seams.
 
 #### Pad-stitch your lapels
- 
+
 Time to feel like a real tailor, and pad-stitch those lapels.
 
-Make sure to make the stitches a bit smaller towards the lapel tip, 
+Make sure to make the stitches a bit smaller towards the lapel tip,
 to make sure it lies flat against the chest, curling a bit inward instead of outward.
 
-> If you're not sure how to pad-stitch the lapels, [let us know](https://chat.freesewing.org/) 
+> If you're not sure how to pad-stitch the lapels, [let us know](https://chat.freesewing.org/)
 and we'll make an attempt to document it.
 
 #### Tape the lapel edge and roll line
@@ -174,7 +174,7 @@ Keep in mind that:
 > your stitches will show on the front.
 >
 > At the same time, you should not secure the tape only to your canvas either.
-> Instead, you should try to catch a few threads of your fabric on every stitch, so that the tape is 
+> Instead, you should try to catch a few threads of your fabric on every stitch, so that the tape is
 > secured in place, yet the stitches don't show at the front.
 >
 > This is less of an issue above the break point of your lapel where the fabric will be on the backside of the lapel.
@@ -186,10 +186,10 @@ Keep in mind that:
 
 ![Close the sides](closeSides.svg)
 
-Place your front with the good side up, and your side on it with the good side down.  
+Place your front with the good side up, and your side on it with the good side down.
 Align the front/side seams, pin them in place if you feel like it, and sew them togther.
 
-Place this down with the good side up, and place your back on top with the good side down.  
+Place this down with the good side up, and place your back on top with the good side down.
 Align the back/side seams, pin them in place if you feel like it, and sew them togther.
 
 > Make sure the canvas does not get caught in the seam.
@@ -232,13 +232,10 @@ Make sure the canvas does not get caught in the seam.
 ##### Align the shoulder notches
 
 Make sure to carefully align the shoulders based on the notches.
-Because of the different shape of the back and front panels on the neck side, 
-the fabric edge looks different. So aligning those edges will not give you 
+Because of the different shape of the back and front panels on the neck side,
+the fabric edge looks different. So aligning those edges will not give you
 what you need.
 
 So make sure to align the notches. It's what they're there for.
 
 </Note>
-
-
-

--- a/org/docs/patterns/jaeger/instructions/en.md
+++ b/org/docs/patterns/jaeger/instructions/en.md
@@ -43,7 +43,6 @@ Apply a rectangular piece of light fusible interfacing around the chest pocket a
 > Sportcoats are typically made from somewhat heavier fabrics.
 > That, and the fact that I prefer to use canvas rather than fusible interfacing,
 > means that I don't interface the front with fusible.
-{.fs-bq}
 
 #### Baste the chest welt outline, mark top line endpoints
 
@@ -144,7 +143,7 @@ Cut out the chest canvas piece. Align it along the roll line, and baste it in pl
 
 Now baste the front canvas and chest piece to your front. Keep in mind that the canvas has no seam allowance.
 
-> Base it a bit inwards from the seam line so you can fold it away when sewing these seams later.
+> Base it a bit inwards from the seam line so you can fold it away when sewing these seams later.  
 > You don't want your canvas to get caught in the seams.
 
 #### Pad-stitch your lapels
@@ -178,7 +177,6 @@ Keep in mind that:
 > secured in place, yet the stitches don't show at the front.
 >
 > This is less of an issue above the break point of your lapel where the fabric will be on the backside of the lapel.
-{.fs-bq}
 
 ### Close the body
 
@@ -186,10 +184,10 @@ Keep in mind that:
 
 ![Close the sides](closeSides.svg)
 
-Place your front with the good side up, and your side on it with the good side down.
+Place your front with the good side up, and your side on it with the good side down.  
 Align the front/side seams, pin them in place if you feel like it, and sew them togther.
 
-Place this down with the good side up, and place your back on top with the good side down.
+Place this down with the good side up, and place your back on top with the good side down.  
 Align the back/side seams, pin them in place if you feel like it, and sew them togther.
 
 > Make sure the canvas does not get caught in the seam.
@@ -200,7 +198,6 @@ Align the back/side seams, pin them in place if you feel like it, and sew them t
 >
 > Sew the downward part of the side/back seam and the sideways part that forms the vent.
 > Do not sew downwards after that.
-{.fs-bq}
 
 #### Close the back seam
 

--- a/org/docs/patterns/paco/instructions/en.md
+++ b/org/docs/patterns/paco/instructions/en.md
@@ -2,21 +2,21 @@
 
 ##### A note on seam finishes
 
-Before you get started, you'll want to decide on your method of seam finishing, or how you tidy 
-up the raw seams along the legs of your pants to keep them from fraying. There are a lot of 
-options for this. Common choices are serging the raw edges, or using French seams to encase 
+Before you get started, you'll want to decide on your method of seam finishing, or how you tidy
+up the raw seams along the legs of your pants to keep them from fraying. There are a lot of
+options for this. Common choices are serging the raw edges, or using French seams to encase
 the raw edges.
 
-For these instructions, we'll assume that you are using a serger for seam finishes, but we'll 
-also provide alternatives. Other options for finishing seams include trimming them with pinking 
-shears, stitching a zig-zag along the edge of the seam to keep it from fraying, or binding with 
+For these instructions, we'll assume that you are using a serger for seam finishes, but we'll
+also provide alternatives. Other options for finishing seams include trimming them with pinking
+shears, stitching a zig-zag along the edge of the seam to keep it from fraying, or binding with
 bias tape.
  </Tip>
 
-## Step 1: Costruct the back pockets
+## Step 1: Construct the back pockets
 
-Are you planning to insert welt pockets in the back of your Paco pants? Is so, awesome! 
-This is arguably the trickiest part, and we'll accomplish it first. If not, you can skip 
+Are you planning to insert welt pockets in the back of your Paco pants? Is so, awesome!
+This is arguably the trickiest part, and we'll accomplish it first. If not, you can skip
 ahead to the next step, preparing the front pockets.
 
 Construct the welt pockets at the back of your trousers, including the pocket bag.
@@ -25,40 +25,40 @@ Construct the welt pockets at the back of your trousers, including the pocket ba
 
 ##### Welt pockets
 
-Constructing a welt pocket is a technique that is used is different garments. That is why it's 
+Constructing a welt pocket is a technique that is used is different garments. That is why it's
 branched it off into its own documentation page.
 
-There’s both written documentation and a video series that shows you how to do it, so even if 
+There’s both written documentation and a video series that shows you how to do it, so even if
 you’ve never made welt pockets before, you’ll be fine.
 
 [To the welt pockets documentation](https://freesewing.org/docs/sewing/double-welt-pockets/)
 
 </Tip>
 
-<!--- One tricky bit, this documentation is for double welts, but this is I think a single welt? 
+<!--- One tricky bit, this documentation is for double welts, but this is I think a single welt?
 Does it need a note to that effect? --->
 
 ## Step 2: Prepare the front pockets
-Your pockets are cut from a lining material, which can save on weight and bulk, but also means 
-that you'll want to hide them a little bit inside the side seam, so the lining doesn't show. 
-The flap along the outside seam of each leg is for just this purpose. 
+Your pockets are cut from a lining material, which can save on weight and bulk, but also means
+that you'll want to hide them a little bit inside the side seam, so the lining doesn't show.
+The flap along the outside seam of each leg is for just this purpose.
 
-If you are using a serger, serge the curved edges of your pocket pieces. Then, serge along the 
+If you are using a serger, serge the curved edges of your pocket pieces. Then, serge along the
 long edges of the pocket flaps.
 
 ![Front pockets with serged edges](step02.jpg)
 
 ## Step 3: Attach pockets to pants
 
-With [good sides together](https://freesewing.org/docs/sewing/good-sides-together/), line up the 
-markings on the edge of the pocket bag with the ends of the flap along the outside seam of the 
+With [good sides together](https://freesewing.org/docs/sewing/good-sides-together/), line up the
+markings on the edge of the pocket bag with the ends of the flap along the outside seam of the
 front leg. Sew together. Repeat for second leg.
 
 ![Pockets sewn to front pants](step03.jpg)
 
-Now do the same with the back legs. With good sides together, line up the markings on the edge of 
-the pocket bag with the ends of the flap along the outside seam of the back leg. Before sewing, 
-make sure that your left leg front and back are attached to one pocket, and your right leg front 
+Now do the same with the back legs. With good sides together, line up the markings on the edge of
+the pocket bag with the ends of the flap along the outside seam of the back leg. Before sewing,
+make sure that your left leg front and back are attached to one pocket, and your right leg front
 and back are attached to the other. Sew together.
 
 Press all seams toward the pants (away from the pocket bag).
@@ -67,7 +67,7 @@ Press all seams toward the pants (away from the pocket bag).
 
 <Note>
 
-Optional: You can understitch here, a millimeter or two in from the seam on each side of the pocket 
+Optional: You can understitch here, a millimeter or two in from the seam on each side of the pocket
 bag, to secure the flaps and pocket bag all together the way you pressed them.
 
 </Note>
@@ -80,8 +80,8 @@ You should now have two big pieces, each with a front and back leg attached by a
 
 ![Attached pockets and legs](step04.jpg)
 
-Take one of the pieces, and place the front and back leg good sides together. Align the outer 
-side seam, so that the side seam of the leg pieces match up, and the pocket bag edges are aligned, 
+Take one of the pieces, and place the front and back leg good sides together. Align the outer
+side seam, so that the side seam of the leg pieces match up, and the pocket bag edges are aligned,
 with good sides together.
 
 ![Aligned pockets and side seams](step04b.jpg)
@@ -90,14 +90,14 @@ with good sides together.
 
 You'll sew two separate seams to stitch up your side seams while leaving your pockets open.
 
-Start at the top of the leg pieces. Sew along the side seam, pivoting as you reach the pocket bag. 
-You can also shorten your stitch length here to reinforce the corner of the pocket opening. 
+Start at the top of the leg pieces. Sew along the side seam, pivoting as you reach the pocket bag.
+You can also shorten your stitch length here to reinforce the corner of the pocket opening.
 Follow the side seam, pivoting again and ending at the top of the pocket.
 
-Next, you'll close the bottom of the pocket bag and stitch the rest of the side seam. Start at the 
-bottom edge of the pocket bag, sewing along the bottom of the pocket, then pivoting when you get to 
-the side seam of the pants. You can use a shorter stitch length for the first few stitches on the 
-side seam, to reinforce the bottom of the pocket opening. Sew all the way down the leg side seam. 
+Next, you'll close the bottom of the pocket bag and stitch the rest of the side seam. Start at the
+bottom edge of the pocket bag, sewing along the bottom of the pocket, then pivoting when you get to
+the side seam of the pants. You can use a shorter stitch length for the first few stitches on the
+side seam, to reinforce the bottom of the pocket opening. Sew all the way down the leg side seam.
 
 Repeat for second leg.
 
@@ -105,22 +105,22 @@ Repeat for second leg.
 
 ## Step 6: Finish the side seams
 
-Finishing these seams requires a touch of delicacy, especially around the tops of the pockets. 
+Finishing these seams requires a touch of delicacy, especially around the tops of the pockets.
 
-It would be difficult to finish the top part of the side seam with a serger, so we'll use a 
-zig-zag stitch. Starting at the top of the side seam, zig-zag stitch along the raw edge of the seam 
-allowance, pivoting around the pocket opening. Continue the zig-zag stitch up the side of the pocket, 
+It would be difficult to finish the top part of the side seam with a serger, so we'll use a
+zig-zag stitch. Starting at the top of the side seam, zig-zag stitch along the raw edge of the seam
+allowance, pivoting around the pocket opening. Continue the zig-zag stitch up the side of the pocket,
 unless you've serged your pockets already (in which case you can stop when you reach the pocket).
 
-The bottom opening of the pocket is a tight corner. To finish the seam around this corner, zig-zag 
-stitch the raw edge of the seam allowance, starting where it joins the pocket, pivoting at the 
-corner and continuing about 5 cm (2 in.) down the side seam. You can continue finishing the side seam 
-with a zig-zag stitch all the way down. Alternatively, you can serge the side seam, making sure to 
+The bottom opening of the pocket is a tight corner. To finish the seam around this corner, zig-zag
+stitch the raw edge of the seam allowance, starting where it joins the pocket, pivoting at the
+corner and continuing about 5 cm (2 in.) down the side seam. You can continue finishing the side seam
+with a zig-zag stitch all the way down. Alternatively, you can serge the side seam, making sure to
 stop the line of serger stitches a little ways from the pocket.
 
 <Note>
 
-Make sure to secure these serger stitches. They won't be caught in any other seams, so they risk 
+Make sure to secure these serger stitches. They won't be caught in any other seams, so they risk
 unravelling if left unsecured.
 
 </Note>
@@ -133,47 +133,47 @@ Press the side seams toward the front.
 
 <Note>
 
-This may feel counterintuitive, as a lot of pants suggest pressing the side seams to the back. 
-However, with inseam pockets, you'll want the pockets pressed toward the front of the pants. Your 
-pockets will be fighting your side seam if you press the seam to the back, so we'll press it all 
+This may feel counterintuitive, as a lot of pants suggest pressing the side seams to the back.
+However, with inseam pockets, you'll want the pockets pressed toward the front of the pants. Your
+pockets will be fighting your side seam if you press the seam to the back, so we'll press it all
 to the front. This will will result in a smoother finish.
 
 </Note>
 
 <Note>
 
-The corners of a pocket opening are one of the most likely places to wear out or tear, especially 
-if you use your pockets a lot. If you're worried about tearing at the corners of your pockets, or 
-if your fabric is more delicate, you can reinforce the pocket openings with bar tacks along the seam 
+The corners of a pocket opening are one of the most likely places to wear out or tear, especially
+if you use your pockets a lot. If you're worried about tearing at the corners of your pockets, or
+if your fabric is more delicate, you can reinforce the pocket openings with bar tacks along the seam
 line, just outside the pocket openings.
 
 </Note>
 
 ## Step 7: Anchor pocket bag to waist
 
-The pockets in Paco are anchored at the waist. This means that you can put things in your pockets 
-without them becoming unsightly bump that’s just dangling around in your trouser leg. 
+The pockets in Paco are anchored at the waist. This means that you can put things in your pockets
+without them becoming unsightly bump that’s just dangling around in your trouser leg.
 
-To anchor each pocket, align the top of the pocket with the mark along the waistline of your 
-pattern. Sew a line of basting stitches inside your seam allowance to hold the pocket in place. 
+To anchor each pocket, align the top of the pocket with the mark along the waistline of your
+pattern. Sew a line of basting stitches inside your seam allowance to hold the pocket in place.
 
 ![Anchored pocket bags showing basted seam](step07.jpg)
 
 ## Step 8: Sew and finish the inseams
 
-Align the inseams with good sides together, then sew up the inseams. Finish the seams the same way 
+Align the inseams with good sides together, then sew up the inseams. Finish the seams the same way
 you finished the side seams. Press inseams to the back.
 
 ## Step 9: Sew and finish crotch seam
 
-To attach the individual legs, flip one leg good side out (it doesn't matter which leg), then 
-place it inside the other leg, good sides together. You should now have what looks like just one 
-pant leg, with wrong sides visible. Align the center front, center back, and inseams of each leg, 
+To attach the individual legs, flip one leg good side out (it doesn't matter which leg), then
+place it inside the other leg, good sides together. You should now have what looks like just one
+pant leg, with wrong sides visible. Align the center front, center back, and inseams of each leg,
 then pin along the length of the crotch seam. Sew and finish the crotch seam.
 
 <Note>
 
-If you sew from center front to center back, it's easier to keep your inseam seam allowances 
+If you sew from center front to center back, it's easier to keep your inseam seam allowances
 pressed to the back as they feed through the machine.
 
 </Note>
@@ -181,17 +181,17 @@ pressed to the back as they feed through the machine.
 <!--- Insert image --->
 
 ## Step 10: Place eyelets for the draw string (optional)
-Mark the middle of your waistband length. Fold one of your waistband pieces double, and mark the 
+Mark the middle of your waistband length. Fold one of your waistband pieces double, and mark the
 middle of the width (do not take the seam allowance into account).
 
-A bit to the left and right of this, you can add two eyelets to pass a drawstring through. Because 
+A bit to the left and right of this, you can add two eyelets to pass a drawstring through. Because
 your Paco pants have elastic in the waistband, as well, this is a nice detail, but is not required.
 
 <Tip>
 
 ##### It’s best to add some reinforcement
 
-If you've chosen a fabric that is slippery, drapey, or thin, you might want to add some reinforcement 
+If you've chosen a fabric that is slippery, drapey, or thin, you might want to add some reinforcement
 behind these eyelets. A bit of interfacing or a leftover piece of denim will do just fine.
 
 </Tip>
@@ -199,8 +199,8 @@ behind these eyelets. A bit of interfacing or a leftover piece of denim will do 
 <!--- Insert image --->
 
 ## Step 11: Prepare the waist elastic
-There’s no magic formula for the length of your elastic. So you wrap it around your waist and pull 
-it tight until you get a good fit. Paco is cut to sit at the high hip, so make sure your elastic is 
+There’s no magic formula for the length of your elastic. So you wrap it around your waist and pull
+it tight until you get a good fit. Paco is cut to sit at the high hip, so make sure your elastic is
 long enough to sit comfortably at the high hip.
 
 Mark this length, cut the elastic, and join the two ends together.
@@ -208,47 +208,47 @@ Mark this length, cut the elastic, and join the two ends together.
 ![Elastic joined with a series of zig-zag stitches](step11.jpg)
 
 ## Step 12: Join the waistband
-Place the two waistband pieces good sides together, and align the short edges. Sew the short edges 
-together, then press open. These will be inside the waistband, so you don't need to finish the edges 
+Place the two waistband pieces good sides together, and align the short edges. Sew the short edges
+together, then press open. These will be inside the waistband, so you don't need to finish the edges
 of these seams unless your fabric is particularly likely to fray.
 
 ![Joined waistband pieces](step12.jpg)
 
-Fold the waistband double along the length, with good sides out, and press. This fold will be the 
+Fold the waistband double along the length, with good sides out, and press. This fold will be the
 top of your waistband.
 
 ## Step 13: Attach the waistband
 
-You have two options for attaching your waistband. One is a bit simpler, but leaves an exposed seam 
+You have two options for attaching your waistband. One is a bit simpler, but leaves an exposed seam
 on the inside. The other is a bit more fiddly, but it encloses the raw edges of your fabric.
 
 ### The simpler method
-Keep your waistband folded double, and place the elastic inside. Make sure to align the place where 
+Keep your waistband folded double, and place the elastic inside. Make sure to align the place where
 the elastic is joined with the back of the waistband (opposite the eyelets).
 
 <!--- Insert image with elastic sticking out, step13 --->
 
-Find the center front of your waistband (easy if there are eyelets, if not just fold it double), 
-and align that with the center front seam of your pants. Make sure that your waistband is outside 
-of your pants, with good sides together. Pin in place. 
+Find the center front of your waistband (easy if there are eyelets, if not just fold it double),
+and align that with the center front seam of your pants. Make sure that your waistband is outside
+of your pants, with good sides together. Pin in place.
 
 <Tip>
 
 ##### Mind your eyelets
 
-If you’ve made eyelets in your waistband, double check that they are placed towards the outside, 
+If you’ve made eyelets in your waistband, double check that they are placed towards the outside,
 not the inside of your waistband.
 
 </Tip>
 
-Next, align the center front of your waistband with the center front seam. Pin in place. Then, 
+Next, align the center front of your waistband with the center front seam. Pin in place. Then,
 align the center backs and pin in place, adding additional pins around the waistband as needed.
 
 Sew the waistband to the pants, as close to the the elastic as you can, but don’t sew into the elastic.
 
 <!--- Insert image, step13b --->
 
-It’s fine to not sew too close the first time around, and once your elastic is attached and encased, 
+It’s fine to not sew too close the first time around, and once your elastic is attached and encased,
 make a second round to sew it a bit more snugly.
 
 Remove any basting stitches from the tops of the pocket bags.
@@ -257,35 +257,35 @@ Finish the seam with a serger or other method.
 
 ### The enclosed seam method
 
-Open the waistband. You will still be able to see the fold along its length, but you will be working 
+Open the waistband. You will still be able to see the fold along its length, but you will be working
 with each side of the waistband individually.
 
-Find the center front of your waistband (easy if there are eyelets, if not just fold it double), and 
-align that with the center front seam of your pants. Make sure that your waistband is outside of your 
-pants, with good sides together. Pin in place. 
+Find the center front of your waistband (easy if there are eyelets, if not just fold it double), and
+align that with the center front seam of your pants. Make sure that your waistband is outside of your
+pants, with good sides together. Pin in place.
 
 <Tip>
 
 ##### Mind your eyelets
-To make sure your eyelets will end up on the outside, make sure they are closer to the top of your 
+To make sure your eyelets will end up on the outside, make sure they are closer to the top of your
 waistband, above the fold, for now.
 
 </Tip>
 
 <!--- Insert image, step 13c --->
 
-Next, align the center back of your waistband with the center back seam. Pin in place. Then, add 
+Next, align the center back of your waistband with the center back seam. Pin in place. Then, add
 additional pins around the waistband as needed.
 
 Sew the waistband to the pants.
 
-Press the waistband up. Press the seam allowance in on the opposite side of the waistband, maintaining 
+Press the waistband up. Press the seam allowance in on the opposite side of the waistband, maintaining
 the fold along the center of the waistband.
 
 ![Pressed waistband, prepared for sewing](step13d.jpg)
 
-Refold the waistband, turning half the waistband to the inside. Pin so that the seam allowance on the 
-inside is just below the seam joining the waistband to the pants, and pin in place around the waistband. 
+Refold the waistband, turning half the waistband to the inside. Pin so that the seam allowance on the
+inside is just below the seam joining the waistband to the pants, and pin in place around the waistband.
 From the outside, stitch in the ditch, catching the inner waistband as you go.
 
 <!--- Probably put a note here about stitching in the ditch? --->
@@ -294,7 +294,7 @@ From the outside, stitch in the ditch, catching the inner waistband as you go.
 
 ## Step 14: Prepare the cuff elastic
 
-As you did with the waistband elastic, wrap the elastic for your cuff around your ankle and pull it 
+As you did with the waistband elastic, wrap the elastic for your cuff around your ankle and pull it
 tight until you get a good fit.
 
 Mark this length, cut the elastic, and join the two ends together. Repeat for the other cuff elastic.
@@ -302,25 +302,25 @@ Mark this length, cut the elastic, and join the two ends together. Repeat for th
 ![Elastic joined with zig-zag stitching](step14.jpg)
 
 ## Step 15: Join the cuffs
-Fold each cuff with good sides together, aligning the short edges. For each cuff, sew the short edges 
-together, then press open. These will be inside the cuff, so you don't need to finish the edges of 
+Fold each cuff with good sides together, aligning the short edges. For each cuff, sew the short edges
+together, then press open. These will be inside the cuff, so you don't need to finish the edges of
 these seams unless your fabric is particularly likely to fray.
 
 ![Joined cuffs](step15.jpg)
 
-Fold each cuff double along the length, with good sides out, and press. This fold will be the bottom 
+Fold each cuff double along the length, with good sides out, and press. This fold will be the bottom
 of your cuffs.
 
 <!--- Insert image --->
 
 ## Step 16: Attach the cuffs
 
-You will attach your cuffs the same way that you attached the waistband. As with the waistband, 
+You will attach your cuffs the same way that you attached the waistband. As with the waistband,
 there are two options - a simpler choice, and a choice without exposed seams on the inside.
 
 <Note>
 
- If your sewing machine has a detachable bed (usually removed to expose the "free arm" for sewing 
+ If your sewing machine has a detachable bed (usually removed to expose the "free arm" for sewing
  sleeve cuffs), this will make sewing the cuffs easier.
 
  </Note>
@@ -331,17 +331,17 @@ Keep your cuffs folded double, and place the elastic inside.
 
 <!--- Insert image, step16 --->
 
-Align the seam in the cuff with the inseam of the pants. Make sure that your cuff is outside of 
+Align the seam in the cuff with the inseam of the pants. Make sure that your cuff is outside of
 your pants, with good sides together. Pin in place, then pin the rest of the way around the cuff.
 
 <Tip>
 
 ##### Pinning the cuffs
 
-The elastic will make the cuffs more difficult to pin. To make sure that your cuffs are pinned evenly 
-to the pants, place your second pin on the opposite side of the leg opening from the first. You can 
-stretch the elastic to make sure that everything is lined up smoothly, then place your next pins halfway 
-between the first two. Continue this way, pinning halfway between other pins, until you feel confident 
+The elastic will make the cuffs more difficult to pin. To make sure that your cuffs are pinned evenly
+to the pants, place your second pin on the opposite side of the leg opening from the first. You can
+stretch the elastic to make sure that everything is lined up smoothly, then place your next pins halfway
+between the first two. Continue this way, pinning halfway between other pins, until you feel confident
 there are enough.
 
 </Tip>
@@ -356,37 +356,37 @@ Finish the seam with a serger or other method.
 
 ### The enclosed seam method
 
-Open the cuff. You will still be able to see the fold along its length, but you will be working with 
+Open the cuff. You will still be able to see the fold along its length, but you will be working with
 each side of the cuff individually.
 
-Align the seam in the cuff with the inseam of the pants. Make sure that your cuff is outside of your 
+Align the seam in the cuff with the inseam of the pants. Make sure that your cuff is outside of your
 pants, with good sides together. Pin in place, then pin the rest of the way around the cuff.
 
 Sew the cuff to the pants.
 
 ![Sewing the cuff to the pants](step16d.jpg)
 
-Press the cuff away from the pants. Press the seam allowance in on the opposite side of the cuff, maintaining the 
+Press the cuff away from the pants. Press the seam allowance in on the opposite side of the cuff, maintaining the
 fold along the center of the cuff.
 
 ![Pressed cuff, with elastic inside, being pinned closed](step16e.jpg)
 
-Refold the cuff, turning half the cuff to the inside. Pin so that the seam allowance on the inside 
-is just past the seam joining the cuff to the pants, and pin in place around the cuff. From the outside, 
+Refold the cuff, turning half the cuff to the inside. Pin so that the seam allowance on the inside
+is just past the seam joining the cuff to the pants, and pin in place around the cuff. From the outside,
 stitch in the ditch, catching the inner cuff as you go.
 
 ![Cuff on the free arm of sewing machine, showing stitching in the ditch](step16f.jpg)
 
 ## Step 17: Stitching the cuffs and waistband (optional)
 
-If you have wider cuff elastic, you may want to stitch a horizontal line halfway up the cuff. This will 
-hold your elastic in place and help keep it from folding or twisting. Make sure to stretch the elastic 
-evenly as you sew, so that it gathers the fabric evenly. (If you sew without stretching the elastic, 
+If you have wider cuff elastic, you may want to stitch a horizontal line halfway up the cuff. This will
+hold your elastic in place and help keep it from folding or twisting. Make sure to stretch the elastic
+evenly as you sew, so that it gathers the fabric evenly. (If you sew without stretching the elastic,
 you risk lumpy gathers and a leg opening too narrow to get your foot through.)
 
 <!--- You could also do a zig-zag stitch here, but I think straight probably looks nicer? --->
 
-If you like the look, you can also sew more than one line of stitches, evenly spaced between the top 
+If you like the look, you can also sew more than one line of stitches, evenly spaced between the top
 and bottom of the cuff.
 
 <!--- Insert image --->
@@ -395,7 +395,7 @@ You can do the same for the waistband.
 
 <Note>
 
-If you put in eyelets for a drawstring, sew a line of stitches above the eyelets and a separate line 
+If you put in eyelets for a drawstring, sew a line of stitches above the eyelets and a separate line
 below the eyelets, leaving a channel wide enough for your drawstring.
 
 </Note>
@@ -403,14 +403,14 @@ below the eyelets, leaving a channel wide enough for your drawstring.
 <!--- Insert image --->
 
 ## Step 18: Thread a draw string around the waist (optional)
-If you put eyelets in your waistband, thread a drawstring through one eyelet, around the waist, and 
+If you put eyelets in your waistband, thread a drawstring through one eyelet, around the waist, and
 out of the other eyelet.
 
 <Note>
 
-There are tools to make this task easier, but one that almost everyone has is a simple safety pin. 
-Pin the safety pin to one end of your drawstring, then push it through the channel. The safety pin 
-will be easier to maneuver through the fabric, and it will pull the drawstring along with it. 
+There are tools to make this task easier, but one that almost everyone has is a simple safety pin.
+Pin the safety pin to one end of your drawstring, then push it through the channel. The safety pin
+will be easier to maneuver through the fabric, and it will pull the drawstring along with it.
 
 </Note>
 

--- a/org/docs/patterns/sandy/instructions/en.md
+++ b/org/docs/patterns/sandy/instructions/en.md
@@ -1,6 +1,6 @@
 <Note>
 
-####### Sandy documentation is missing
+###### Sandy documentation is missing
 
 The documentation for this pattern is yet to be written.
 

--- a/org/docs/patterns/titan/instructions/en.md
+++ b/org/docs/patterns/titan/instructions/en.md
@@ -3,7 +3,7 @@
 
 Join the outseam (the seam that runs along the side of your leg) of the front and back.
 
-Repeat the step for teh other leg, but **make sure they are the mirror image of each other**. 
+Repeat the step for the other leg, but **make sure they are the mirror image of each other**.
 
 ### Step 2: Join the inseam
 
@@ -23,7 +23,7 @@ You can now align and sew the cross seam.
 
 ###### You probably want to insert a zipper
 
-You should insert a zipper or leave the last part of the cross seam open (so you can pin it).  
-If you don't you want be able to put on Titan to check the fit.
+You should insert a zipper or leave the last part of the cross seam open (so you can pin it).
+If you don't you wont be able to put on Titan to check the fit.
 
 </Note>

--- a/org/docs/patterns/titan/instructions/en.md
+++ b/org/docs/patterns/titan/instructions/en.md
@@ -23,7 +23,7 @@ You can now align and sew the cross seam.
 
 ###### You probably want to insert a zipper
 
-You should insert a zipper or leave the last part of the cross seam open (so you can pin it).
+You should insert a zipper or leave the last part of the cross seam open (so you can pin it).  
 If you don't you wont be able to put on Titan to check the fit.
 
 </Note>

--- a/org/docs/patterns/wahid/instructions/en.md
+++ b/org/docs/patterns/wahid/instructions/en.md
@@ -87,13 +87,13 @@ If you haven't marked the four corners of that rectangle yet, you should do so n
 
 #### Attach pocket welt and pocket facing
 
-![Attach pocket welt and pocket facing](05c.png){.fs-row2}
-![Attach pocket welt and pocket facing](05d.png){.fs-row2}
+![Attach pocket welt and pocket facing](05c.png)
+![Attach pocket welt and pocket facing](05d.png)
 
 Place your front piece down with the good side up. We're going to attach the welt to the bottom line of your pocket outline, and the facing to the top line.
 
 > If you've never made a welt pocket before, it can be a bit counterintuitive to attach the pocket on the outside of the garment. Pocket should be on the inside, right?
-> 
+>
 > Relax, the pocket will end up on the inside
 
 Both your pocket welt and your pocket facing have a help line on them. That line needs to line up with the long edges of your pocket.
@@ -138,8 +138,8 @@ Fold them back making sure you to keep your pocket opening a clean rectangle, an
 
 #### Bring the pocket welt to the back, fold and press
 
-![Bring the pocket welt to the front, fold and press](05i.png){.fs-row2}
-![Bring the pocket welt to the front, fold and press](05j.png){.fs-row2}
+![Bring the pocket welt to the front, fold and press](05i.png)
+![Bring the pocket welt to the front, fold and press](05j.png)
 
 Flip the pocket welt with the attache pocket back tot he back side.
 

--- a/org/docs/sewing/trimming/en.md
+++ b/org/docs/sewing/trimming/en.md
@@ -3,7 +3,7 @@ title: Trimming
 ---
 ![Seam allowance being trimmed](trimming.jpg)
 
-Trimming, or to trim, is cutting away excessive SA.
+Trimming, or to trim, is cutting away excessive [seam allowance](/docs/sewing/seam-allowance).
 
 Often the goal of trimming is to reduce bulk in the seams of a garment.
 


### PR DESCRIPTION
Minor issues which stood out while I was reading through the pattern docs. I have my editor configured to strip trailing spaces which has ballooned the diff a bit but this only impacts the rendered output in titan/instructions#26 and jaeger/instructions#147,189,192. These lines were ended with a double space which forces a line break, I was unsure if this was intentional. I can restore the forced breaks if desired.