### PR TITLE
Fix broken links to repo pages

### DIFF
--- a/dev/reference/repos/org/en.md
+++ b/dev/reference/repos/org/en.md
@@ -11,7 +11,7 @@ This is the source code for [FreeSewing.org](https://freesewing.org), our main w
 It's a [JAMStack](https://jamstack.org/) site powered by [Gatsby](https://www.gatsbyjs.org/) and
 hosted by [Netlify](https://www.netlify.com/).
 
-The content (documentation, blog posts, and so on) is kept in [our markdown repository](/repos/markdown) and
+The content (documentation, blog posts, and so on) is kept in [our markdown repository](/reference/repos/markdown) and
 included in this repository as a submodule.
 
 ## Getting started
@@ -28,10 +28,10 @@ npm run develop
 
 <Note>
 
-We're using the `--recurse-submodules` option to fetch the [markdown](/repos/markdown) submodule in one go.
+We're using the `--recurse-submodules` option to fetch the [markdown](/reference/repos/markdown) submodule in one go.
 However, this is only available in newer versions of git.
 
-If after cloning the `markdown` directory is empty, 
+If after cloning the `markdown` directory is empty,
 please check [these alternatives](https://stackoverflow.com/questions/3796927/how-to-git-clone-including-submodules).
 
 </Note>
@@ -60,15 +60,15 @@ Without a backend, certain aspects of the website won't work.
 The backend needs to be configured in the `GATSBY_BACKEND` environment variable.
 
 To facilitate development, our backend is available as a Docker image that you can spin up.
-See [the backend repo](/repos/backend) for more info.
+See [the backend repo](/reference/repos/backend) for more info.
 
 ### Tiler (svg2pdf)
 
 Without an svg2pdf backend (aka the tiler), the website won't be able to generate PDFs for patterns.
 The svg2pdf backend needs to be configured in the `GATSBY_TILER` environment variable.
 
-You can spin up your own version of [our svg2pdf repository](/repos/tile). 
-FreeSewing contributors can also simply point to https://tiler.freesewing.org. 
+You can spin up your own version of [our svg2pdf repository](/reference/repos/tile).
+FreeSewing contributors can also simply point to https://tiler.freesewing.org.
 
 ### Oauth
 
@@ -83,7 +83,7 @@ If you don't setup/configure Oauth, everything will work, except Oath (duh).
 
 ### Algolia
 
-Algolia handles the search on the website. 
+Algolia handles the search on the website.
 
 <Warning>
 
@@ -93,10 +93,10 @@ This feature is not yet implemented.
 
 ## Environment variables
 
-The following variables configure different aspects of our website. 
+The following variables configure different aspects of our website.
 Only `GATSBY_LANGUAGE` is required to get the site up and running.
 
-| Var    | Purpose | Example | 
+| Var    | Purpose | Example |
 |--------|---------|---------|
 | `GATSBY_LANGUAGE` | Determines the language of the site | `en` |
 | `GATSBY_FRONTEND` | URL under which the website is served | `http://localhost:8000/` |


### PR DESCRIPTION
Hey 👋 

First time contributing. Love this project and I hope to contribute more in the future!

I found these broken links while browsing the docs and decided to fix them. I didn't touch the non-English files as the README says to only update English content, but I can easily update the links in those files too if that would be better.

There are also a couple of whitespace changes that my editor automatically changed. Let me know if you would like me to revert them.

Cheers!