### PR TITLE
fix wrong link to knit binding

### DIFF
--- a/org/docs/patterns/aaron/instructions/en.md
+++ b/org/docs/patterns/aaron/instructions/en.md
@@ -39,8 +39,8 @@ Either way, the less sharp bends you have, the easier it will be. So start with 
 
 </Note>
 
-We are going to finish the arm and neck hole with [knit binding](/en/docs/sewing/knit-binding) 
-(note: not a knit band. There's a difference, and it's explained [here](/en/docs/sewing/knit-binding)).
+We are going to finish the arm and neck hole with [knit binding](/docs/sewing/knit-binding) 
+(note: not a knit band. There's a difference, and it's explained [here](/docs/sewing/knit-binding)).
 
 <Note>
 


### PR DESCRIPTION
As reported by Elske on Discord, the link in Aaron to the knit binding docs is not working.
Fix: remove `/en/` in front of link to knit binding docs