### PR TITLE
Add link to I18n files

### DIFF
--- a/dev/guides/best-practices/use-translation-keys/en.md
+++ b/dev/guides/best-practices/use-translation-keys/en.md
@@ -23,3 +23,4 @@ path.seam.attr("data-text", "finishWithBiasTape");
 
 This way, it can be translated.
 
+You can find and browse the translations and available translation keys [in the freesewing/freesewing project](https://github.com/freesewing/freesewing/tree/develop/packages/i18n/src/locales).


### PR DESCRIPTION
I couldn't find the translation files (because the key being referenced in the example didn't exist in the repo,) so have added a link to the base i18n package.

It's a bummer there doesn't seem to be a way to link to this in any relative way, so it has to be linked with the canonical url. If there's a better way to do this here I'm happy to change it.