### PR TITLE
minor fix: typo in heel measurement description

### DIFF
--- a/org/docs/measurements/heel/en.md
+++ b/org/docs/measurements/heel/en.md
@@ -1,6 +1,6 @@
 ---
 title: Heel circumference
 ---
-The **heel circumference** measurement is the narrowest measurment a trouser leg can be so you can still get in to it.
+The **heel circumference** measurement is the narrowest measurement a trouser leg can be so you can still get in to it.
 
 To measure your heel circumference, stretch your foot forward, and run the tape measure around your foot at the widest part of your heel.


### PR DESCRIPTION
fixed spelling of "measurement" in heel measurement description, as noticed by @ttimearl in comment of issue #824 in the`freesewing` monorepo