### PR TITLE
change formulation of body shape =/= gender

### DIFF
--- a/org/docs/faq/breasts/en.md
+++ b/org/docs/faq/breasts/en.md
@@ -16,7 +16,7 @@ These characteristics are generally thought of as _the typical characteristics o
 However, we believe it is best to stay away from this; 
 no body is average and we want to build a gender-inclusive environment. 
 
-We do not want to exclude anyone and we don't agree with the idea that _body shape = gender_. 
+We do not want to exclude anyone and we think that _body shape ≠ gender_. 
 That's why we use the terminology **with breasts** and **without breasts**, 
 simply asking whether a person has breast tissue or not.
 


### PR DESCRIPTION
I've changed the sentence regarding body shape and gender, because when you're just skimming over the text the highlighted "body shape = gender" catches your eye before you see that it's negated. Now "body shape =/= gender" is very prominent, as it should be.