### PR TITLE
dev docs: change dx(), dy(), dist() examples -- markdown

### DIFF
--- a/dev/reference/api/point/dist/en.md
+++ b/dev/reference/api/point/dist/en.md
@@ -16,23 +16,19 @@ Returns the distance between this point and the point you pass it.
 />
 
 ```js
-export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
+let { Point, points, Path, paths } = part.shorthand()
 
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
 
 points.text = points.from
-	.shiftFractionTowards(points.to, 0.6)
-	.attr("data-text", points.from.dist(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note center");
+  .shiftFractionTowards(points.to, 0.6)
+  .attr("data-text", points.from.dist(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note center")
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
-    
-    return part
-}
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
 ```
 

--- a/dev/reference/api/point/dist/en.md
+++ b/dev/reference/api/point/dist/en.md
@@ -16,14 +16,23 @@ Returns the distance between this point and the point you pass it.
 />
 
 ```js
-let { Point, points, Snippet, snippets, macro } = part.shorthand();
+export default (part) => {
+    let { Point, points, Path, paths} = part.shorthand()
 
-points.from = new Point(10, 10);
-points.to = new Point(90, 40);
+  points.from = new Point(10, 10)
+  points.to = new Point(80, 70)
 
-macro("ld", {
-  from: points.from,
-  to: points.to
-});
+points.text = points.from
+	.shiftFractionTowards(points.to, 0.6)
+	.attr("data-text", points.from.dist(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note center");
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
+    
+    return part
+}
 ```
 

--- a/dev/reference/api/point/dx/en.md
+++ b/dev/reference/api/point/dx/en.md
@@ -14,15 +14,38 @@ Returns the delta along the X-axis between this point and the point you pass it.
 />
 
 ```js
-let { Point, points, Snippet, snippets, macro } = part.shorthand();
 
-points.from = new Point(10, 10);
-points.to = new Point(90, 40);
+export default (part) => {
+    let { Point, points, Path, paths} = part.shorthand()
 
-macro("hd", {
-  from: points.from,
-  to: points.to,
-  y: 25
-});
+  points.from = new Point(10, 10)
+  points.to = new Point(80, 70)
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
+
+    points.totop = points.from.shift(0,points.from.dx(points.to))
+
+    points.text_dx = points.from
+	.shiftFractionTowards(points.totop, 0.6)
+	.shiftFractionTowards(points.to,0.1)
+	.attr("data-text", points.from.dx(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note center");
+
+    paths.line_dx = new Path()
+	.move(points.from)
+	.line(points.totop)
+	.attr("class", "dashed");
+    
+    paths.line_dy = new Path()
+	.move(points.to)
+	.line(points.totop)
+	.attr("class", "dashed");
+  
+    return part
+}
+
 ```
 

--- a/dev/reference/api/point/dx/en.md
+++ b/dev/reference/api/point/dx/en.md
@@ -14,38 +14,32 @@ Returns the delta along the X-axis between this point and the point you pass it.
 />
 
 ```js
+let { Point, points, Path, paths} = part.shorthand()
 
-export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
-
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
 
-    points.totop = points.from.shift(0,points.from.dx(points.to))
+points.totop = points.from.shift(0,points.from.dx(points.to))
 
-    points.text_dx = points.from
-	.shiftFractionTowards(points.totop, 0.6)
-	.shiftFractionTowards(points.to,0.1)
-	.attr("data-text", points.from.dx(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note center");
+points.text_dx = points.from
+  .shiftFractionTowards(points.totop, 0.6)
+  .shiftFractionTowards(points.to,0.1)
+  .attr("data-text", points.from.dx(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note center")
 
-    paths.line_dx = new Path()
-	.move(points.from)
-	.line(points.totop)
-	.attr("class", "dashed");
+paths.line_dx = new Path()
+  .move(points.from)
+  .line(points.totop)
+  .attr("class", "dashed")
     
-    paths.line_dy = new Path()
-	.move(points.to)
-	.line(points.totop)
-	.attr("class", "dashed");
-  
-    return part
-}
-
+paths.line_dy = new Path()
+  .move(points.to)
+  .line(points.totop)
+  .attr("class", "dashed")
 ```
 

--- a/dev/reference/api/point/dx/en.md
+++ b/dev/reference/api/point/dx/en.md
@@ -14,7 +14,7 @@ Returns the delta along the X-axis between this point and the point you pass it.
 />
 
 ```js
-let { Point, points, Path, paths} = part.shorthand()
+let { Point, points, Path, paths } = part.shorthand()
 
 points.from = new Point(10, 10)
 points.to = new Point(80, 70)

--- a/dev/reference/api/point/dy/en.md
+++ b/dev/reference/api/point/dy/en.md
@@ -14,36 +14,30 @@ Returns the delta along the Y-axis between this point and the point you pass it.
 />
 
 ```js
-export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
+let { Point, points, Path, paths } = part.shorthand()
 
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
 
-    points.totop = points.from.shift(0,points.from.dx(points.to))
+points.totop = points.from.shift(0,points.from.dx(points.to))
 
-    paths.line_dx = new Path()
-	.move(points.from)
-	.line(points.totop)
-	.attr("class", "dashed");
+paths.line_dx = new Path()
+  .move(points.from)
+  .line(points.totop)
+  .attr("class", "dashed")
 
-        points.text_dy = points.totop
-	.shiftFractionTowards(points.to, 0.4)
-	.attr("data-text", points.from.dy(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note right");
-
-    
-    paths.line_dy = new Path()
-	.move(points.to)
-	.line(points.totop)
-	.attr("class", "dashed");
+points.text_dy = points.totop
+  .shiftFractionTowards(points.to, 0.4)
+  .attr("data-text", points.from.dy(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note right")
   
-    return part
-}
-
+paths.line_dy = new Path()
+  .move(points.to)
+  .line(points.totop)
+  .attr("class", "dashed")
 ```

--- a/dev/reference/api/point/dy/en.md
+++ b/dev/reference/api/point/dy/en.md
@@ -14,14 +14,36 @@ Returns the delta along the Y-axis between this point and the point you pass it.
 />
 
 ```js
-let { Point, points, Snippet, snippets, macro } = part.shorthand();
+export default (part) => {
+    let { Point, points, Path, paths} = part.shorthand()
 
-points.from = new Point(10, 10);
-points.to = new Point(90, 40);
+  points.from = new Point(10, 10)
+  points.to = new Point(80, 70)
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
 
-macro("vd", {
-  from: points.to,
-  to: points.from,
-  x: 50
-});
+    points.totop = points.from.shift(0,points.from.dx(points.to))
+
+    paths.line_dx = new Path()
+	.move(points.from)
+	.line(points.totop)
+	.attr("class", "dashed");
+
+        points.text_dy = points.totop
+	.shiftFractionTowards(points.to, 0.4)
+	.attr("data-text", points.from.dy(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note right");
+
+    
+    paths.line_dy = new Path()
+	.move(points.to)
+	.line(points.totop)
+	.attr("class", "dashed");
+  
+    return part
+}
+
 ```


### PR DESCRIPTION
As mentioned in issue [#1111](https://github.com/freesewing/freesewing/issues/1111), I have rewritten the examples given in the `dist()`, `dx()` and `dy()` dev docs to show the usage of these methods. It doesn't look as nice as before, but is hopefully useful as an example.

This is the corresponding PR for `markdown`. (PR for `freesewing` [here](https://github.com/freesewing/freesewing/pull/1126))

Feedback and improvements welcome :)