### PR TITLE
Update Holmes Cutting en.md

### DIFF
--- a/org/docs/patterns/holmes/cutting/en.md
+++ b/org/docs/patterns/holmes/cutting/en.md
@@ -1,5 +1,5 @@
 ---
-Holmes Cutting
+title: Holmes Cutting
 ---
 The **gore** pattern piece needs to be cut on the fold to create a whole piece.
 

--- a/org/docs/patterns/holmes/cutting/en.md
+++ b/org/docs/patterns/holmes/cutting/en.md
@@ -1,14 +1,28 @@
 ---
-title: Cutting
+title: Holmes Cutting
 ---
+The **gore** pattern piece needs to be cut on the fold to create a whole piece.
 
+### Materials
  - **Main fabric**
-   - Cut the amount of **gores** the you selected in the pattern options
-   - Cut **2 ear** parts
-   - Cut **4 brim** parts
+   - Cut the amount of **gores** you selected in the pattern options
+   - Cut **4 ear** parts or Cut **2 ear** from main and lining.
+   - Cut **4 bill** parts
  - **Lining fabric**
-   - Cut the amount of **gores** the you selected in the pattern options
-   - Cut **2 ear** parts
- - **Plastic**
-   - Cut **2 brim**.
+   - Cut the amount of **gores** you selected in the pattern options
+ - **Bill Insert Material**
+   - Cut **2 bill inserts**. Use your bill pattern piece with no seam allowance.
 
+### Optional Fabric Ties
+If you don't wish to use ribbon for your ties you can make them out of fabric. Simply cut 4 crossgrain strips of an 1" (2.5cm) or width of your choosen + seam allowances wide and sew two tubes leaving one of the short sides open for turning. Clip the corners and trim seams. Turn out an press. If desired you can ***Edgestitch*** or ***Topstitch*** the tubes to stop the fabric from shifting. The raw edge of the tubes can then be concealed in the ear flap seam when constructing the ear flaps.
+
+<Note>
+
+It is recommended to draft the pattern nett and use the pattern to trace the seam lines onto fabric and add the seam allowance on the fabric rather than the pattern. This to allow for a more precise sew which is needed for a hat. Recommended seam allowance 1/4" (6mm) on the sides of the gores, ear flaps and outer curve of the bills. 1/2" (1.3cm) for the bottom of the gores, ear flaps and inner curve of the bills. With these seam allowances you will not have to trim the allowances if you do not want to.  
+
+</Note>
+<Warning>
+
+It is recommended to make a mock-up with your gore pattern first before cutting your fabrics. This is to test the length and ease of the gore piece. Make sure to cut off the bottom seam allowance before trying it on. If it is too tight who will need to re-draft the pattern with more ease (longer head circumference) just remember the ease is split across each gore. If the peak is too high you may want to re-draft the pattern with the gore length reduced. Once re-drafted make another mock-up to check whether you are satified with the changes or not. Repeat again if you are not satisfied.
+
+</Warning>

--- a/org/docs/patterns/holmes/cutting/en.md
+++ b/org/docs/patterns/holmes/cutting/en.md
@@ -1,5 +1,5 @@
 ---
-title: Holmes Cutting
+Holmes Cutting
 ---
 The **gore** pattern piece needs to be cut on the fold to create a whole piece.
 


### PR DESCRIPTION
-Added how to cut gore pattern piece
-Updated Cutting list. Ear flaps are generally cut just from the main fabric but left the option for lining. This may need to be updated in the instructions
-Added Bill insert cutting.
-Added Optional Fabric ties
-Added Note about using nett patterns for a more precise sew.
-Added Warning about making a mock-up with the gore pieces first. The pattern doesn't draft with any ease options and it sort of needs some . I plan to look into adding more options for Holmes but either way this is useful if it is the first time making it for someone. 

Changes still needed
-Update to termonology to align with free sewing. I may change the naming of some of the pieces as  gore should be crown, ear should be ear flap. Visor can be bill but visor still works.