### PR TITLE
feat(docs): add hands tip for measuring hpstobust

### DIFF
--- a/org/docs/measurements/hpstobust/en.md
+++ b/org/docs/measurements/hpstobust/en.md
@@ -17,3 +17,21 @@ To measure your HPS to bust, first [localize your HPS point](/docs/measurements/
 Then measure straight down to the line that forms your chest circumference/bust span.
 
 The point of this measurement is to locate the fullest part of your bust vertically on your torso.
+
+<Tip>
+
+##### Think about which hand you're using
+
+If you measure yourself, you might try to hold your measuring tape up to your shoulder with the hand on 
+the same side of your body as the shoulder you're measuring. So, for example, you could be holding the top of 
+the tape up to your right shoulder with your right hand, while your left hand is holding the end. 
+But that means you distort the length you are trying to measure by raising your arm on the same side. 
+You might not think there is a difference, but all is connected in the world of physiology, and
+doing this could lead to an error of ~2.5cm (~1 inch) in your measurement.  
+Simply switch your hands around, and you get a more accurate measurement.
+
+For best results, get a second person to take your measurements (if possible).
+  
+</Tip>
+
+  


### PR DESCRIPTION
Add tip about using which hand while measuring `hpstobust`, as proposed by @georgeMHL. It's still a bit wordy, so subsequent improving edits are welcome. 
I also thought a bit about having it duplicated on other HPS to... measurements, but haven't added it to them so far (mostly because it's so much text).

Closes [#1188](https://github.com/freesewing/freesewing/issues/1188).